### PR TITLE
Fixed client query params for DNS records in the infoblox.Records func

### DIFF
--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -456,7 +456,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("infoblox-ssl-verify", "When using the Infoblox provider, specify whether to verify the SSL certificate (default: true, disable with --no-infoblox-ssl-verify)").Default(strconv.FormatBool(defaultConfig.InfobloxSSLVerify)).BoolVar(&cfg.InfobloxSSLVerify)
 	app.Flag("infoblox-client-cert", "Path to a certificate file (public part) to be used for client-based authentication when connecting to a NIOS server").Default(defaultConfig.InfobloxClientCert).StringVar(&cfg.InfobloxClientCert)
 	app.Flag("infoblox-client-key", "Path to a certificate key (private part) to be used for client-based authentication when connecting to a NIOS server").Default(defaultConfig.InfobloxClientKey).StringVar(&cfg.InfobloxClientKey)
-	app.Flag("infoblox-view", "DNS view (default: \"\")").Default(defaultConfig.InfobloxView).StringVar(&cfg.InfobloxView)
+	app.Flag("infoblox-view", "DNS view (required)").StringVar(&cfg.InfobloxView)
 	app.Flag("infoblox-max-results", "Add _max_results as query parameter to the URL on all API requests. The default is 0 which means _max_results is not set and the default of the server is used.").Default(strconv.Itoa(defaultConfig.InfobloxMaxResults)).IntVar(&cfg.InfobloxMaxResults)
 	app.Flag("infoblox-fqdn-regex", "Apply this regular expression as a filter for obtaining zone_auth objects. This is disabled by default.").Default(defaultConfig.InfobloxFQDNRegEx).StringVar(&cfg.InfobloxFQDNRegEx)
 	app.Flag("infoblox-create-ptr", "When using the Infoblox provider, create a ptr entry in addition to an entry").Default(strconv.FormatBool(defaultConfig.InfobloxCreatePTR)).BoolVar(&cfg.InfobloxCreatePTR)

--- a/provider/infoblox/infoblox.go
+++ b/provider/infoblox/infoblox.go
@@ -128,6 +128,10 @@ func (mrb *ExtendedRequestBuilder) BuildRequest(t ibclient.RequestType, obj ibcl
 
 // NewInfobloxProvider creates a new Infoblox provider.
 func NewInfobloxProvider(ibStartupCfg StartupConfig) (*ProviderConfig, error) {
+	if strings.Trim(ibStartupCfg.View, " \a\b\t\n\r\f\v") == "" {
+		return nil, fmt.Errorf("non-empty DNS view's name is required")
+	}
+
 	hostCfg := ibclient.HostConfig{
 		Host:    ibStartupCfg.Host,
 		Port:    strconv.Itoa(ibStartupCfg.Port),


### PR DESCRIPTION
**Description**

Fixed client query params for DNS records in the infoblox.Records function

* Previously when calling ibclient.GetObject function, provider used "obj" 
  parameter to search for some records by view and zone.
  
* To use view and zone for the record search, those parameters should be 
  specified in the queryParams function parameter instead.

* Related ticket: NIOS-85168.
